### PR TITLE
Add Proc as a type for ActiveJob retry_on attempts

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Add Proc as a supported type for ActiveJob retry_on attempts:
+
+    Example:
+
+     ```ruby
+    class RetryJob < ActiveJob::Base
+      retry_on ProcRetryError, attempts: ->(executions) { executions < 2 }
+      # ...
+    end
+    ```
+
+    *Rose Wiegley*
+
 *   Add support for Sidekiq's transaction-aware client
 
     *Jonathan del Strother*

--- a/activejob/test/cases/exceptions_test.rb
+++ b/activejob/test/cases/exceptions_test.rb
@@ -307,6 +307,26 @@ class ExceptionsTest < ActiveSupport::TestCase
     assert_equal "Successfully completed job", JobBuffer.values[9]
   end
 
+  test "successfully retry job throwing ProcRetryError" do
+    RetryJob.perform_later "ProcRetryError", 2
+
+    assert_equal [
+      "Raised ProcRetryError for the 1st time",
+      "Successfully completed job"
+    ], JobBuffer.values
+  end
+
+  test "successfully throw an error when ProcRetryError returns false from its proc" do
+    assert_raises ProcRetryError do
+      RetryJob.perform_later "ProcRetryError", 3
+    end
+
+    assert_equal [
+      "Raised ProcRetryError for the 1st time",
+      "Raised ProcRetryError for the 2nd time"
+    ], JobBuffer.values
+  end
+
   test "running a job enqueued by AJ 5.2" do
     job = RetryJob.new("DefaultsError", 6)
     job.exception_executions = nil # This is how jobs from Rails 5.2 will look

--- a/activejob/test/jobs/retry_job.rb
+++ b/activejob/test/jobs/retry_job.rb
@@ -18,6 +18,7 @@ class FirstDiscardableErrorOfTwo < StandardError; end
 class SecondDiscardableErrorOfTwo < StandardError; end
 class CustomDiscardableError < StandardError; end
 class UnlimitedRetryError < StandardError; end
+class ProcRetryError < StandardError; end
 
 class RetryJob < ActiveJob::Base
   retry_on DefaultsError
@@ -31,6 +32,7 @@ class RetryJob < ActiveJob::Base
   retry_on(CustomCatchError) { |job, error| JobBuffer.add("Dealt with a job that failed to retry in a custom way after #{job.arguments.second} attempts. Message: #{error.message}") }
   retry_on(ActiveJob::DeserializationError) { |job, error| JobBuffer.add("Raised #{error.class} for the #{job.executions} time") }
   retry_on UnlimitedRetryError, attempts: :unlimited
+  retry_on ProcRetryError, attempts: ->(executions) { executions < 2 }
 
   discard_on DiscardableError
   discard_on FirstDiscardableErrorOfTwo, SecondDiscardableErrorOfTwo

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -553,6 +553,9 @@ module ActiveRecord
 
     # This must be defined before the inherited hook, below
     class Current < Migration # :nodoc:
+      def compatible_table_definition(t)
+        t
+      end
     end
 
     def self.inherited(subclass) # :nodoc:

--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -97,7 +97,7 @@ module ActiveRecord
             class << t
               prepend TableDefinition
             end
-            t
+            super
           end
       end
 
@@ -162,7 +162,7 @@ module ActiveRecord
             class << t
               prepend TableDefinition
             end
-            t
+            super
           end
       end
 

--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -256,7 +256,7 @@ module ActiveRecord
       end
 
       def test_options_are_not_validated
-        migration = Class.new(ActiveRecord::Migration[7.0]) {
+        migration = Class.new(ActiveRecord::Migration[4.2]) {
           def migrate(x)
             create_table :tests, wrong_id: false do |t|
               t.references :some_table, wrong_primary_key: true

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -3158,15 +3158,15 @@ NOTE: Defined in `active_support/core_ext/regexp.rb`.
 Extensions to `Range`
 ---------------------
 
-### `to_s`
+### `to_fs`
 
-Active Support extends the method `Range#to_s` so that it understands an optional format argument. As of this writing the only supported non-default format is `:db`:
+Active Support defines `Range#to_fs` as an alternative to `to_s` that understands an optional format argument. As of this writing the only supported non-default format is `:db`:
 
 ```ruby
-(Date.today..Date.tomorrow).to_s
+(Date.today..Date.tomorrow).to_fs
 # => "2009-10-25..2009-10-26"
 
-(Date.today..Date.tomorrow).to_s(:db)
+(Date.today..Date.tomorrow).to_fs(:db)
 # => "BETWEEN '2009-10-25' AND '2009-10-26'"
 ```
 

--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -24,13 +24,13 @@ This guide will walk you through the I18n API and contains a tutorial on how to 
 After reading this guide, you will know:
 
 * How I18n works in Ruby on Rails
-* How to correctly use I18n into a RESTful application in various ways
+* How to correctly use I18n in a RESTful application in various ways
 * How to use I18n to translate Active Record errors or Action Mailer E-mail subjects
 * Some other tools to go further with the translation process of your application
 
 --------------------------------------------------------------------------------
 
-NOTE: The Ruby I18n framework provides you with all necessary means for internationalization/localization of your Rails application. You may, also use various gems available to add additional functionality or features. See the [rails-i18n gem](https://github.com/svenfuchs/rails-i18n) for more information.
+NOTE: The Ruby I18n framework provides you with all necessary means for internationalization/localization of your Rails application. You may also use various gems available to add additional functionality or features. See the [rails-i18n gem](https://github.com/svenfuchs/rails-i18n) for more information.
 
 How I18n in Ruby on Rails Works
 -------------------------------
@@ -42,7 +42,7 @@ Internationalization is a complex problem. Natural languages differ in so many w
 
 As part of this solution, **every static string in the Rails framework** - e.g. Active Record validation messages, time and date formats - **has been internationalized**. _Localization_ of a Rails application means defining translated values for these strings in desired languages.
 
-To localize store and update _content_ in your application (e.g. translate blog posts), see the [Translating model content](#translating-model-content) section.
+To localize, store, and update _content_ in your application (e.g. translate blog posts), see the [Translating model content](#translating-model-content) section.
 
 ### The Overall Architecture of the Library
 
@@ -601,7 +601,7 @@ You should have a good understanding of using the i18n library now and know how
 to internationalize a basic Rails application. In the following chapters, we'll
 cover its features in more depth.
 
-These chapters will show examples using both the `I18n.translate` method as well as the [`translate` view helper method](https://api.rubyonrails.org/classes/ActionView/Helpers/TranslationHelper.html#method-i-translate) (noting the additional feature provide by the view helper method).
+These chapters will show examples using both the `I18n.translate` method as well as the [`translate` view helper method](https://api.rubyonrails.org/classes/ActionView/Helpers/TranslationHelper.html#method-i-translate) (noting the additional features provided by the view helper method).
 
 Covered are features like these:
 
@@ -791,7 +791,7 @@ Alternatively, the separate gem [rails-i18n](https://github.com/svenfuchs/rails-
 
 ### Setting and Passing a Locale
 
-The locale can be either set pseudo-globally to `I18n.locale` (which uses `Thread.current` like, e.g., `Time.zone`) or can be passed as an option to `#translate` and `#localize`.
+The locale can be either set pseudo-globally to `I18n.locale` (which uses `Thread.current` in the same way as, for example, `Time.zone`) or can be passed as an option to `#translate` and `#localize`.
 
 If no locale is passed, `I18n.locale` is used:
 

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/content_security_policy.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/content_security_policy.rb.tt
@@ -16,7 +16,7 @@
 #     # policy.report_uri "/csp-violation-report-endpoint"
 #   end
 #
-#   # Generate session nonces for permitted importmap, inline scripts and inline styles.
+#   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
 #   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
 #   config.content_security_policy_nonce_directives = %w(script-src style-src)
 #


### PR DESCRIPTION
Note: If you are reading this here is the [actual PR](https://github.com/rails/rails/pull/46245) for this change. (Where I did not accidentally fill the branch with non-rebased other commits.)

### Motivation / Background

This Pull Request has been created because I needed `retry_on attempts:` to use more complex logic than an Integer.

In my specific case I was creating a concern for Jobs that would use `retry_on` to allow jobs to quietly fail and retry. The concern was going to use a method to allow attempts to be customized in individual jobs. 
```
    included do
      retry_on(QuietRetryError, wait: :exponentially_longer, attempts: quiet_retry_attempts) do
        # ...
      end
    end
```

However this ran into a state where the method needed to be defined and run when the concern was included instead of being available later in the job. It would be very fragile to have to define the method before including the concern. This lead to me to looking at if attempts accepted anything besides an integer. It did not but I saw there was already a pattern in place for wait to accept a Proc. I thought if that pattern was repeated for attempts than it would allow more flexibility for configuring attempts.

My original thought was to have the Proc for attempts return a number similar to what the Proc for wait does. However, on thinking about it I decided that still did not leave much flexibility because attempts would still be determined by a number. Instead I switched it to return true/false so if the next attempt occurred could be determined by whatever logic was implemented in the Proc.

### Detail

This Pull Request changes ActiveJob retry_on attempts so it will accept a Proc.

ActiveJob retry_on allowed the wait option to be set as a Proc that calculates the wait but did not give the same option for attempts. attempts could be set to only a number of times to attempt or unlimited. However, jobs sometimes need different logic than number of executions to determine if they should try again.

This PR adds support for setting attempts to a Proc that returns either true or false. On true the retry will occur.

As a an example:

    retry_on ProcRetryError, attempts: ->(executions) { executions < 2 }

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] There are no typos in commit messages and comments.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Feature branch is up-to-date with `main` (if not - rebase it).
* [ ] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [x] Tests are added if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [ ] PR is not in a draft state.
* [ ] CI is passing.

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
